### PR TITLE
Quick Fix for Wrong Argument Splitting on wget

### DIFF
--- a/fetch.py
+++ b/fetch.py
@@ -33,7 +33,7 @@ def fetch_wget(out_dir, link, overwrite=False, requisites=True, timeout=TIMEOUT)
         CMD = [
             *'wget --timestamping --adjust-extension --no-parent'.split(' '),                # Docs: https://www.gnu.org/software/wget/manual/wget.html
             *(('--page-requisites', '--convert-links') if requisites else ()),
-            *(('--user-agent="{}"'.format(WGET_USER_AGENT)) if WGET_USER_AGENT else ()),
+            *(('--user-agent="{}"'.format(WGET_USER_AGENT), '') if WGET_USER_AGENT else ()),
             link['url'],
         ]
         end = progress(timeout, prefix='      ')


### PR DESCRIPTION
When setting the user agent, the resulting CLI arguments for wget where `['wget', '--timestamping', '--adjust-extension', '--no-parent', '--page-requisites', '--convert-links', '-', '-', 'u', 's', 'e', 'r', '-', 'a', 'g', 'e', 'n', 't', '=', '"', 'L', 'y', 'n', 'x', '"', 'https://example.org']`, with this fix it turns into `['wget', '--timestamping', '--adjust-extension', '--no-parent', '--page-requisites', '--convert-links', '--user-agent="Lynx"', '', 'https://example.org']`