### PR TITLE
Treat AttributeError as an acceptable parse failure

### DIFF
--- a/parse.py
+++ b/parse.py
@@ -52,7 +52,7 @@ def parse_links(path):
                 links += list(parser_func(file))
                 if links:
                     break
-            except (ValueError, TypeError, IndexError, etree.ParseError):
+            except (ValueError, TypeError, IndexError, AttributeError, etree.ParseError):
                 # parser not supported on this file
                 pass
 


### PR DESCRIPTION
This PR intends to fix the following stacktrace when updating from a Pinboard RSS feed:

```
Traceback (most recent call last):
 File "./archive.py", line 115, in <module>
   links = get_links(source, archive_path=archive_path)
 File "./archive.py", line 46, in get_links
   raw_links = parse_links(new_links_file_path)
 File "/home/cdzombak/bookmark-archiver/parse.py", line 52, in parse_links
   links += list(parser_func(file))
 File "/home/cdzombak/bookmark-archiver/parse.py", line 209, in parse_medium_rss_feed
   items = root.find("channel").findall("item")
AttributeError: 'NoneType' object has no attribute 'findall'
```

I think #71 should have added `AttributeError` as another error which indicates the parser that's being tried doesn't work on the given input.