### PR TITLE
Optionally import only new links

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,11 @@ You can run it in parallel by using the `resume` feature, or by manually splitti
 ```
 Users have reported running it with 50k+ bookmarks with success (though it will take more RAM while running).
 
+If you already imported a huge list of bookmarks and want to import only new
+bookmarks, you can use the `ONLY_NEW` environment variable. This is useful if
+you want to import a bookmark dump periodically and want to skip broken links
+which are already in the index.
+
 ## Configuration
 
 You can tweak parameters via environment variables, or by editing `config.py` directly:
@@ -158,6 +163,7 @@ env CHROME_BINARY=google-chrome-stable RESOLUTION=1440,900 FETCH_PDF=False ./arc
 
 **Archive Options:**
  - maximum allowed download time per link: `TIMEOUT` values: [`60`]/`30`/`...`
+ - import only new links: `ONLY_NEW` values `True`/[`False`]
  - archive methods (values: [`True`]/`False`):
    - fetch page with wget: `FETCH_WGET`
    - fetch images/css/js with wget: `FETCH_WGET_REQUISITES` (True is highly recommended)

--- a/archiver/archive.py
+++ b/archiver/archive.py
@@ -64,7 +64,7 @@ def merge_links(archive_path=OUTPUT_DIR, import_path=None, only_new=False):
         all_links = validate_links(existing_links + all_links)
     
     num_new_links = len(all_links) - len(existing_links)
-    if num_new_links:
+    if num_new_links and not only_new:
         print('[{green}+{reset}] [{}] Adding {} new links from {} to {}/index.json'.format(
             datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
             num_new_links,
@@ -166,7 +166,8 @@ if __name__ == '__main__':
 
     # Step 1: Parse the links and dedupe them with existing archive
     links = merge_links(archive_path=out_dir, import_path=source, only_new=False)
-    
+    new_links = merge_links(archive_path=out_dir, import_path=source, only_new=True)
+
     # Step 2: Write new index
     write_links_index(out_dir=out_dir, links=links)
 
@@ -175,7 +176,6 @@ if __name__ == '__main__':
 
     # Step 4: Run the archive methods for each link
     if ONLY_NEW:
-        new_links = merge_links(archive_path=out_dir, import_path=source, only_new=True)
         update_archive(out_dir, new_links, source=source, resume=resume, append=True)
     else:
         update_archive(out_dir, links, source=source, resume=resume, append=True)

--- a/archiver/config.py
+++ b/archiver/config.py
@@ -13,6 +13,7 @@ from subprocess import run, PIPE
 IS_TTY = sys.stdout.isatty()
 USE_COLOR =              os.getenv('USE_COLOR',              str(IS_TTY)        ).lower() == 'true'
 SHOW_PROGRESS =          os.getenv('SHOW_PROGRESS',          str(IS_TTY)        ).lower() == 'true'
+ONLY_NEW =               os.getenv('ONLY_NEW',               'False'            ).lower() == 'true'
 FETCH_WGET =             os.getenv('FETCH_WGET',             'True'             ).lower() == 'true'
 FETCH_WGET_REQUISITES =  os.getenv('FETCH_WGET_REQUISITES',  'True'             ).lower() == 'true'
 FETCH_AUDIO =            os.getenv('FETCH_AUDIO',            'False'            ).lower() == 'true'

--- a/archiver/links.py
+++ b/archiver/links.py
@@ -74,21 +74,14 @@ def validate_links(links):
 
     return list(links)
 
-def new_links(imported_links, existing_links):
+def new_links(all_links, existing_links):
     """
-    Return all links which are in the imported_links but not in the existing_links.
+    Return all links which are in the all_links but not in the existing_links.
     This is used to determine which links are new and not indexed jet. Set the
     ONLY_NEW environment variable to activate this filter mechanism.
     """
-    new_links = []
-    for i_link in imported_links:
-        found_link_in_existing_links = False
-        for e_link in existing_links:
-            if i_link['url'] == e_link['url']:
-                found_link_in_existing_links = True
-        if not found_link_in_existing_links:
-            new_links.append(i_link)
-    return new_links
+    existing_urls = list(map(lambda l: l['url'], existing_links))
+    return list(filter(lambda l: l['url'] not in existing_urls, all_links))
 
 def archivable_links(links):
     """remove chrome://, about:// or other schemed links that cant be archived"""

--- a/archiver/links.py
+++ b/archiver/links.py
@@ -74,6 +74,21 @@ def validate_links(links):
 
     return list(links)
 
+def new_links(imported_links, existing_links):
+    """
+    Return all links which are in the imported_links but not in the existing_links.
+    This is used to determine which links are new and not indexed jet. Set the
+    ONLY_NEW environment variable to activate this filter mechanism.
+    """
+    new_links = []
+    for i_link in imported_links:
+        found_link_in_existing_links = False
+        for e_link in existing_links:
+            if i_link['url'] == e_link['url']:
+                found_link_in_existing_links = True
+        if not found_link_in_existing_links:
+            new_links.append(i_link)
+    return new_links
 
 def archivable_links(links):
     """remove chrome://, about:// or other schemed links that cant be archived"""

--- a/archiver/links.py
+++ b/archiver/links.py
@@ -80,8 +80,8 @@ def new_links(all_links, existing_links):
     This is used to determine which links are new and not indexed jet. Set the
     ONLY_NEW environment variable to activate this filter mechanism.
     """
-    existing_urls = list(map(lambda l: l['url'], existing_links))
-    return list(filter(lambda l: l['url'] not in existing_urls, all_links))
+    existing_urls = {link['url'] for link in existing_links}
+    return [link for link in all_links if link['url'] not in existing_urls]
 
 def archivable_links(links):
     """remove chrome://, about:// or other schemed links that cant be archived"""


### PR DESCRIPTION
When importing a huge list of links periodically (from a big dump of
links from a bookmark service for example) with a lot of broken links,
this links will always be rechecked. To skip this, the environment
variable ONLY_NEW can be used to only import new links and skip the rest
altogether. This partially fixes #95.