### PR TITLE
Add dummy favicon entry so FETCH_FAVICON='False' isn't failing

### DIFF
--- a/archiver/links.py
+++ b/archiver/links.py
@@ -60,6 +60,7 @@ def validate_links(links):
         link['title'] = unescape(link['title'])
         link['latest'] = link.get('latest') or {}
         
+        latest = link['latest']
         if not link['latest'].get('wget'):
             link['latest']['wget'] = wget_output_path(link)
 
@@ -71,6 +72,9 @@ def validate_links(links):
 
         if not link['latest'].get('dom'):
             link['latest']['dom'] = None
+
+        if not latest.get('favicon'):
+            latest['favicon'] = None
 
     return list(links)
 


### PR DESCRIPTION
Previously you would get
```
  Traceback (most recent call last):
  File "./../archive", line 184, in <module>
    update_archive(out_dir, links, source=source, resume=resume, append=True)
  File "./../archive", line 108, in update_archive
    archive_links(archive_path, links, source=source, resume=resume)
  File "/L/tmp/bookmark-archiver/archiver/archive_methods.py", line 73, in archive_links
    raise e
  File "/L/tmp/bookmark-archiver/archiver/archive_methods.py", line 57, in archive_links
    archive_link(link_dir, link)
  File "/L/tmp/bookmark-archiver/archiver/archive_methods.py", line 115, in archive_link
    write_link_index(link_dir, link)
  File "/L/tmp/bookmark-archiver/archiver/index.py", line 111, in write_link_index
    write_html_link_index(out_dir, link)
  File "/L/tmp/bookmark-archiver/archiver/index.py", line 152, in write_html_link_index
    'wget': link['latest'].get('wget') or wget_output_path(link),
  File "/usr/lib/python3.6/string.py", line 130, in substitute
    return self.pattern.sub(convert, self.template)
  File "/usr/lib/python3.6/string.py", line 123, in convert
    return str(mapping[named])
KeyError: 'favicon'
```
because of unmatched `$favicon` in the HTML template string