### PR TITLE
Fix 'Too many open files' error.

### DIFF
--- a/archiver/util.py
+++ b/archiver/util.py
@@ -161,7 +161,13 @@ def progress(seconds=TIMEOUT, prefix=''):
 
     def end():
         """immediately finish progress and clear the progressbar line"""
+        nonlocal p
+        if p is None: # protect from double termination
+            return
+
         p.terminate()
+        p = None
+
         sys.stdout.write('\r{}{}\r'.format((' ' * TERM_WIDTH), ANSI['reset']))  # clear whole terminal line
         sys.stdout.flush()
 


### PR DESCRIPTION
Happened before after continuous archiving of few hundreds links (at 800-900th url typically). 

If you run archaver and in parallel, `lsof -p $(pgrep -f archive)`, you'll see PIPE file descriptors leaking.

Fixed by:
* setting process object to `None` to trigger GC finalizer cleanup of pipe descriptors
* protecting against double cleanup